### PR TITLE
Add workingDirectory to pipeline template

### DIFF
--- a/update-jira.yml
+++ b/update-jira.yml
@@ -3,6 +3,10 @@ parameters:
       type: string
     - name: JiraEnvironment
       type: string
+    - name: workingDirectory
+      type: string
+      default: $(Build.SourcesDirectory)
+
 steps:
     - checkout: JiraDeployInfo
     - task: PowerShell@2
@@ -11,6 +15,7 @@ steps:
         pwsh: true
         targetType: filePath
         filePath: DeploymentScript.ps1
+        workingDirectory: "${{ parameters.workingDirectory }}"
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         ATLASSIAN_CLIENT_ID: $(AtlassianClientId)
@@ -18,4 +23,4 @@ steps:
         JIRA_STATE: "${{ parameters.JiraState }}"
         JIRA_ENVIRONMENT: "${{ parameters.JiraEnvironment }}"
         JIRA_DOMAIN: $(JiraDomain)
-      continueOnError: true 
+      continueOnError: true


### PR DESCRIPTION
When following the docs for pipeline usage I hit a problem where the "Update JIRA status" would fail because it couldn't find "DeploymentScript.ps1". In my environment it was due to multi-repo checkout, we `checkout: self` and this caused paths to change for both repos.

This pull request adds an optional `workingDirectory` parameter to the update-jira.yml. It will default to `Build.SourcesDirectory` if not passed in which keeps the current behaviour of the template.

In a multi-repo checkout the repo will be cloned to `vsts/work/1/s/azure-jira-update` and `workingDirectory` needs to be passed in for DeploymentScript.ps1 to be found.