### PR TITLE
fix for regex - find jiraid

### DIFF
--- a/EP.PowerShell.JiraDeployInfo/Private/Find-JiraIDs.ps1
+++ b/EP.PowerShell.JiraDeployInfo/Private/Find-JiraIDs.ps1
@@ -2,7 +2,7 @@ function Find-JiraIDs {
     param (
         $message
     )
-    $pattern = '\w{2,10}-\d{1,4}'
+    $pattern = '\w+-\d+'
     $values = [regex]::Matches($message, $pattern) | Select-Object value 
     Write-Debug ("[JIRA IDs] " + $values)
     $values

--- a/EP.PowerShell.JiraDeployInfo/Private/Find-JiraIDs.ps1
+++ b/EP.PowerShell.JiraDeployInfo/Private/Find-JiraIDs.ps1
@@ -2,7 +2,7 @@ function Find-JiraIDs {
     param (
         $message
     )
-    $pattern = '\w+-\d+'
+    $pattern = '[A-Z]{2,}+-\d{1,10}'
     $values = [regex]::Matches($message, $pattern) | Select-Object value 
     Write-Debug ("[JIRA IDs] " + $values)
     $values


### PR DESCRIPTION
The regex used to read the Jira ticket ID only reads 4 numeric values. In our case, there are at least 6